### PR TITLE
Resolves issue #17, restructures the database schema

### DIFF
--- a/api.py
+++ b/api.py
@@ -65,6 +65,11 @@ def list_droplists(db: sqlite3.Connection = Depends(get_db)):
     droplists = db.execute("SELECT * FROM droplists")
     return {"droplists": droplists.fetchall()}
 
+@app.get("/waitlists")
+def list_waitlists(db: sqlite3.Connection = Depends(get_db)):
+    waitlists = db.execute("SELECT * FROM waitlists")
+    return {"waitlists": waitlists.fetchall()}
+
 @app.get("/students")
 def list_students(db: sqlite3.Connection = Depends(get_db)):
     students = db.execute("SELECT * FROM students")

--- a/scripts/populate/titanonline_clone.ps1
+++ b/scripts/populate/titanonline_clone.ps1
@@ -3,17 +3,20 @@ if (-not (Test-Path -Path ".\var" -PathType Container)) {
     New-Item -Path ".\var\log" -ItemType Directory
 }
 
-# Execute instructors.sql
-Get-Content .\share\instructors.sql | sqlite3 .\var\titanonline_clone.db
-
 # Execute departments.sql
 Get-Content .\share\departments.sql | sqlite3 .\var\titanonline_clone.db
 
 # Execute courses.sql
 Get-Content .\share\courses.sql | sqlite3 .\var\titanonline_clone.db
 
-# Execute droplists.sql
-Get-Content .\share\droplists.sql | sqlite3 .\var\titanonline_clone.db
+# Execute instructors.sql
+Get-Content .\share\instructors.sql | sqlite3 .\var\titanonline_clone.db
+
+# Execute students.sql
+Get-Content .\share\students.sql | sqlite3 .\var\titanonline_clone.db
+
+# Execute classes.sql
+Get-Content .\share\classes.sql | sqlite3 .\var\titanonline_clone.db
 
 # Execute enrollments.sql
 Get-Content .\share\enrollments.sql | sqlite3 .\var\titanonline_clone.db
@@ -21,8 +24,6 @@ Get-Content .\share\enrollments.sql | sqlite3 .\var\titanonline_clone.db
 # Execute waitlists.sql
 Get-Content .\share\waitlists.sql | sqlite3 .\var\titanonline_clone.db
 
-# Execute students.sql
-Get-Content .\share\students.sql | sqlite3 .\var\titanonline_clone.db
+# Execute droplists.sql
+Get-Content .\share\droplists.sql | sqlite3 .\var\titanonline_clone.db
 
-# Execute classes.sql
-Get-Content .\share\classes.sql | sqlite3 .\var\titanonline_clone.db

--- a/scripts/populate/titanonline_clone.sh
+++ b/scripts/populate/titanonline_clone.sh
@@ -7,20 +7,11 @@ if [ ! -d "./var" ]; then
     mkdir -p "./var/log"
 fi
 
-# Execute classes.sql
-cat ./share/classes.sql | sqlite3 ./var/titanonline_clone.db
-
-# Execute courses.sql
-cat ./share/courses.sql | sqlite3 ./var/titanonline_clone.db
-
 # Execute departments.sql
 cat ./share/departments.sql | sqlite3 ./var/titanonline_clone.db
 
-# Execute droplists.sql
-cat ./share/droplists.sql | sqlite3 ./var/titanonline_clone.db
-
-# Execute enrollments.sql
-cat ./share/enrollments.sql | sqlite3 ./var/titanonline_clone.db
+# Execute courses.sql
+cat ./share/courses.sql | sqlite3 ./var/titanonline_clone.db
 
 # Execute instructors.sql
 cat ./share/instructors.sql | sqlite3 ./var/titanonline_clone.db
@@ -28,5 +19,14 @@ cat ./share/instructors.sql | sqlite3 ./var/titanonline_clone.db
 # Execute students.sql
 cat ./share/students.sql | sqlite3 ./var/titanonline_clone.db
 
+# Execute classes.sql
+cat ./share/classes.sql | sqlite3 ./var/titanonline_clone.db
+
+# Execute enrollments.sql
+cat ./share/enrollments.sql | sqlite3 ./var/titanonline_clone.db
+
 # Execute waitlists.sql
 cat ./share/waitlists.sql | sqlite3 ./var/titanonline_clone.db
+
+# Execute droplists.sql
+cat ./share/droplists.sql | sqlite3 ./var/titanonline_clone.db

--- a/share/classes.sql
+++ b/share/classes.sql
@@ -5,17 +5,13 @@ CREATE TABLE classes (
     ClassID INTEGER PRIMARY KEY,
     ClassSectionNumber INTEGER, 
     CourseID INTEGER,
-    DepartmentID INTEGER,
     InstructorID INTEGER,
-    ClassCurrentEnrollment INTEGER,
     ClassMaximumEnrollment INTEGER,
-    CONSTRAINT fk_courses
-    FOREIGN KEY (CourseID) REFERENCES courses(CourseID)
-    CONSTRAINT fk_departments
-    FOREIGN KEY (DepartmentID) REFERENCES departments(DepartmentID)
-    CONSTRAINT fk_instructors
-    FOREIGN KEY (InstructorID) REFERENCES instructors(InstructorID) 
+    CONSTRAINT fk_courses FOREIGN KEY (CourseID) REFERENCES courses(CourseID)
+    CONSTRAINT fk_instructors FOREIGN KEY (InstructorID) REFERENCES instructors(InstructorID) 
 );
-INSERT INTO classes(ClassID, ClassSectionNumber, CourseID, DepartmentID, InstructorID, ClassCurrentEnrollment, ClassMaximumEnrollment) 
-             VALUES(01,01,01,01,01,01,05);
+
+
+INSERT INTO classes(ClassID, ClassSectionNumber, CourseID, InstructorID, ClassMaximumEnrollment) 
+             VALUES(01,01,01,01,05);
 COMMIT;

--- a/share/courses.sql
+++ b/share/courses.sql
@@ -2,14 +2,10 @@ PRAGMA foreign_key=ON;
 BEGIN TRANSACTION;
 DROP TABLE IF EXISTS courses;
 CREATE TABLE courses (
-    -- Notice that we're not using CourseID as CourseCode is used/said more often.
-    -- At this point we are assuming they're the same thing so let's just stick with CourseCode for now.
-    CourseCode INTEGER PRIMARY KEY, 
+    CourseID INTEGER PRIMARY KEY, 
     CourseName VARCHAR,
     DepartmentID INTEGER,
-    CONSTRAINT fk_departments
-    FOREIGN KEY (DepartmentID)
-    REFERENCES departments(DepartmentID)
+    CONSTRAINT fk_departments FOREIGN KEY (DepartmentID) REFERENCES departments(DepartmentID)
 );
-INSERT INTO courses(CourseCode, CourseName, DepartmentID) VALUES(01, 'Intro to Engineering', 01);
+INSERT INTO courses(CourseID, CourseName, DepartmentID) VALUES(01, 'Intro to Computer Science', 01);
 COMMIT;

--- a/share/departments.sql
+++ b/share/departments.sql
@@ -5,8 +5,5 @@ CREATE TABLE departments (
     DepartmentID INTEGER PRIMARY KEY,
     DepartmentName VARCHAR
 );
-INSERT INTO departments(DepartmentID, DepartmentName) VALUES(01, 'Engineering');
-INSERT INTO departments(DepartmentID, DepartmentName) VALUES(02, 'Computer Science');
-INSERT INTO departments(DepartmentID, DepartmentName) VALUES(03, 'Math');
-
+INSERT INTO departments(DepartmentID, DepartmentName) VALUES(01, 'Computer Science');
 COMMIT;

--- a/share/droplists.sql
+++ b/share/droplists.sql
@@ -2,17 +2,12 @@ PRAGMA foreign_keys = ON;
 BEGIN TRANSACTION;
 DROP TABLE IF EXISTS droplists;
 CREATE TABLE droplists (
-    DropListID INTEGER PRIMARY KEY,
     StudentID INTEGER,
     ClassID INTEGER,
-    InstructorID INTEGER,
     AdminDrop BOOLEAN,
-    
-    CONSTRAINT fk_drop_students FOREIGN KEY (StudentID) REFERENCES students(StudentID),
-    CONSTRAINT fk_drop_classes FOREIGN KEY (ClassID) REFERENCES classes(ClassID),
-    CONSTRAINT fk_drop_instructors FOREIGN KEY (InstructorID) REFERENCES instructors(InstructorID)
-
+    PRIMARY KEY(StudentID, ClassID)
+    CONSTRAINT fk_drop_students FOREIGN KEY (StudentID) REFERENCES students(StudentID)
+    CONSTRAINT fk_drop_classes FOREIGN KEY (ClassID) REFERENCES classes(ClassID)
 );
---INSERT INTO droplists(StudentID, ClassID, InstructorID, AdminDrop)
---VALUES (01,01,01,01, 0);
+INSERT INTO droplists(StudentID, ClassID, AdminDrop) VALUES (01, 01, 0);
 COMMIT;

--- a/share/enrollments.sql
+++ b/share/enrollments.sql
@@ -2,16 +2,11 @@ PRAGMA foreign_keys = ON;
 BEGIN TRANSACTION;
 DROP TABLE IF EXISTS enrollments;
 CREATE TABLE enrollments (
-    EnrollmentID INTEGER PRIMARY KEY,
     StudentID INTEGER,
     ClassID INTEGER,
-    InstructorID INTEGER,   
-   
-    CONSTRAINT fk_enroll_students FOREIGN KEY (StudentID) REFERENCES students(StudentID),
-    CONSTRAINT fk_enroll_classes FOREIGN KEY (ClassID) REFERENCES classes(ClassID),
-    CONSTRAINT fk_enroll_instructors FOREIGN KEY (InstructorID) REFERENCES instructors(InstructorID)
+    PRIMARY KEY (StudentID, ClassID)
+    CONSTRAINT fk_enroll_students FOREIGN KEY (StudentID) REFERENCES students(StudentID)
+    CONSTRAINT fk_enroll_classes FOREIGN KEY (ClassID) REFERENCES classes(ClassID)
 );
--- No current class table
---INSERT INTO enrollments(EnrollmentID, StudentID, ClassID, InstructorID)
---VALUES (01,01,01,01);
+INSERT INTO enrollments(StudentID, ClassID) VALUES (02,01);
 COMMIT;

--- a/share/waitlists.sql
+++ b/share/waitlists.sql
@@ -2,16 +2,12 @@ PRAGMA foreign_keys = ON;
 BEGIN TRANSACTION;
 DROP TABLE IF EXISTS waitlists;
 CREATE TABLE waitlists (
-    WaitlistID INTEGER PRIMARY KEY,
     StudentID INTEGER,
     ClassID INTEGER,
-    InstructorID INTEGER,
     WaitlistDate DATE,
-     
-    CONSTRAINT fk_wait_students FOREIGN KEY (StudentID) REFERENCES students(StudentID),
-    CONSTRAINT fk_wait_classes FOREIGN KEY (ClassID) REFERENCES classes(ClassID),
-    CONSTRAINT fk_wait_instructors FOREIGN KEY (InstructorID) REFERENCES instructors(InstructorID)
+    PRIMARY KEY(StudentID, ClassID) 
+    CONSTRAINT fk_wait_students FOREIGN KEY (StudentID) REFERENCES students(StudentID)
+    CONSTRAINT fk_wait_classes FOREIGN KEY (ClassID) REFERENCES classes(ClassID)
 );
---INSERT INTO waitlists(WaitlistID, StudentID, ClassID, InstructorID, WaitlistDate)
---VALUES (01, 01, 01, 01, "2023-09-23");
+INSERT INTO waitlists(StudentID, ClassID, WaitlistDate) VALUES (03, 01, '2023-09-23');
 COMMIT;


### PR DESCRIPTION
Additionally : 
- included missing get in api.py for 'waitlists' table
- added a single entry for each table
- restructured order of sql execution statements in titanonline_clone.ps1 and titanonline_clone.sh (helps with referencing errors)

Please check that the titanonline_clone script works on your machine 